### PR TITLE
Cancel EntityDamageByEntityEvent when vehicle removal success

### DIFF
--- a/src/JaxkDev/Vehicles/Handlers/EventHandler.php
+++ b/src/JaxkDev/Vehicles/Handlers/EventHandler.php
@@ -105,6 +105,7 @@ class EventHandler implements Listener
 								$attacker->sendMessage(Main::$prefix.C::RED."You cannot remove a vehicle with players in it.");
 							}
 							else {
+								$event->setCancelled();
 								$entity->close();
 								$attacker->sendMessage(Main::$prefix . "'" . $entity->getVehicleName() . "' has been removed.");
 							}


### PR DESCRIPTION
This issue fixes errors when removing vehicles because the entity has already been closed, cancelling the event before other plugins mess with it. Fixes #15 #10